### PR TITLE
[ECPDOCKER-38] Pre-check for single container in service definition

### DIFF
--- a/dsl/properties/scripts/DockerClient.groovy
+++ b/dsl/properties/scripts/DockerClient.groovy
@@ -85,8 +85,7 @@ public class DockerClient extends BaseClient {
                 environmentName)
 
         if(serviceDetails.container.size() > 1){
-            logger ERROR, "Services in Docker do not support multiple container images within one service. ${serviceDetails.container.size()} container definitions were found in the ElectricFlow service definition for '${serviceName}'."
-            System.exit(1)
+            efClient.handleProcedureError("Services in Docker do not support multiple container images within one service. ${serviceDetails.container.size()} container definitions were found in the ElectricFlow service definition for '${serviceName}'.")
         }else{
             createOrUpdateService(clusterEndpoint, serviceDetails)
         }

--- a/dsl/properties/scripts/DockerClient.groovy
+++ b/dsl/properties/scripts/DockerClient.groovy
@@ -84,8 +84,13 @@ public class DockerClient extends BaseClient {
                 clusterOrEnvProjectName,
                 environmentName)
 
-        createOrUpdateService(clusterEndpoint, serviceDetails)
-
+        if(serviceDetails.container.size() > 1){
+            logger ERROR, "Services in Docker do not support multiple container images within one service. ${serviceDetails.container.size()} container definitions were found in the ElectricFlow service definition for '${serviceName}'."
+            System.exit(1)
+        }else{
+            createOrUpdateService(clusterEndpoint, serviceDetails)
+        }
+        
         /*
         
         def serviceEndpoint = getDeployedServiceEndpoint(clusterEndpoint, namespace, serviceDetails, accessToken)


### PR DESCRIPTION
Added pre-check to verify that ElectricFlow service definition contains single container. If not, "Deploy Service" exits with failure msg.