### PR TITLE
[ECPDOCKER-16] [ECPDOCKER-41]

### DIFF
--- a/dsl/procedures/createConfiguration/steps/testConnection.groovy
+++ b/dsl/procedures/createConfiguration/steps/testConnection.groovy
@@ -33,6 +33,8 @@ if (efClient.toBoolean(actualParams.get('testConnection'))) {
 		keyFile.text = key.password
 		System.setProperty("docker.tls.verify", "1")
 		System.setProperty("docker.cert.path","${tempDir}/certs")
+    }else{
+        System.setProperty("docker.tls.verify", "")
     }
 
 	def endpoint = actualParams.get('endpoint')

--- a/dsl/properties/scripts/DockerClient.groovy
+++ b/dsl/properties/scripts/DockerClient.groovy
@@ -24,6 +24,8 @@ public class DockerClient extends BaseClient {
         if (pluginConfig.credential.password){
             // If docker client private key is provided in plugin config then enable TLS mode
             System.setProperty("docker.tls.verify", "1")
+        }else{
+            System.setProperty("docker.tls.verify", "")
         }
         dockerClient = new DockerClientImpl(pluginConfig.endpoint)
         


### PR DESCRIPTION
If client private key is empty in plugin configuration then disable TLS verification