### PR TITLE
Support for overlay networks

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -8,5 +8,5 @@
   <key>EC-Docker</key>
   <configure>ec_config</configure>
   <label>EC-Docker</label>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
 </plugin>

--- a/dsl/procedures/defineService/form.xml
+++ b/dsl/procedures/defineService/form.xml
@@ -85,14 +85,18 @@
         <property>networkType</property>
         <value>2</value>
         <option>
-            <name>Ingress</name>
+            <name>Ingress (Swarm Mode)</name>
             <value>ingress</value>
         </option>
         <option>
-            <name>Overlay</name>
+            <name>Overlay (Swarm Mode)</name>
             <value>overlay</value>
         </option>
-        <documentation>Type of network to create for application.</documentation>
+        <option>
+            <name>Bridge (Docker Engine Mode)</name>
+            <value>bridge</value>
+        </option>
+        <documentation>Type of network to create for application. Select "Ingress" or "Overlay" for Swarm mode,  "Bridge" for standalone Docker engine.</documentation>
         <required>0</required>
     </formElement>
 </editor>

--- a/dsl/procedures/defineService/form.xml
+++ b/dsl/procedures/defineService/form.xml
@@ -72,4 +72,27 @@
         <required>0</required>
         <documentation>Name to use for the service being deployed instead of the name of the service in Deploy.</documentation>
     </formElement>
+    <formElement>
+        <type>entry</type>
+        <label>Network Name:</label>
+        <property>networkName</property>
+        <required>0</required>
+        <documentation>Name of the network to create for application.</documentation>
+    </formElement>
+    <formElement>
+        <type>select</type>
+        <label>Network Type:</label>
+        <property>networkType</property>
+        <value>2</value>
+        <option>
+            <name>Ingress</name>
+            <value>ingress</value>
+        </option>
+        <option>
+            <name>Overlay</name>
+            <value>overlay</value>
+        </option>
+        <documentation>Type of network to create for application.</documentation>
+        <required>0</required>
+    </formElement>
 </editor>

--- a/dsl/procedures/defineService/serviceMappingsForm.xml
+++ b/dsl/procedures/defineService/serviceMappingsForm.xml
@@ -23,4 +23,27 @@
         <required>0</required>
         <documentation>Name for the service in Docker. If no override value is specified here, the service name in ElectricFlow will be used to name the Docker service.</documentation>
     </formElement>
+    <formElement>
+        <type>entry</type>
+        <label>Network Name:</label>
+        <property>networkName</property>
+        <required>0</required>
+        <documentation>Name of the network to create for application.</documentation>
+    </formElement>
+    <formElement>
+        <type>select</type>
+        <label>Network Type:</label>
+        <property>networkType</property>
+        <value>2</value>
+        <option>
+            <name>Ingress</name>
+            <value>ingress</value>
+        </option>
+        <option>
+            <name>Overlay</name>
+            <value>overlay</value>
+        </option>
+        <documentation>Type of network to create for application.</documentation>
+        <required>0</required>
+    </formElement>
 </editor>

--- a/dsl/procedures/defineService/serviceMappingsForm.xml
+++ b/dsl/procedures/defineService/serviceMappingsForm.xml
@@ -36,14 +36,18 @@
         <property>networkType</property>
         <value>2</value>
         <option>
-            <name>Ingress</name>
+            <name>Ingress (Swarm Mode)</name>
             <value>ingress</value>
         </option>
         <option>
-            <name>Overlay</name>
+            <name>Overlay (Swarm Mode)</name>
             <value>overlay</value>
         </option>
-        <documentation>Type of network to create for application.</documentation>
+        <option>
+            <name>Bridge (Docker Engine Mode)</name>
+            <value>bridge</value>
+        </option>
+        <documentation>Type of network to create for application. Select "Ingress" or "Overlay" for Swarm mode,  "Bridge" for standalone Docker engine.</documentation>
         <required>0</required>
     </formElement>
 </editor>

--- a/dsl/properties/scripts/DockerClient.groovy
+++ b/dsl/properties/scripts/DockerClient.groovy
@@ -238,13 +238,23 @@ public class DockerClient extends BaseClient {
                 ingress = false
             }
 
+            def driver, scope
+
+            if(networkType == "bridge"){
+                driver = "bridge"
+                scope = "local"
+            }else{
+                driver = "overlay"
+                scope = "swarm"
+            }
+
             def payload = [
-                    Driver: "overlay",
+                    Driver: driver,
                     "IPAM": [
                             "Driver": "default"
                     ],
                     "Ingress" : ingress,
-                    "Scope": "swarm"
+                    "Scope": scope
             ]
 
             def response = dockerClient.createNetwork(networkName, payload)
@@ -711,6 +721,8 @@ public class DockerClient extends BaseClient {
            memoryReservation = convertMBsToBytes(container.memorySize.toFloat())
         }
 
+        String networkName = getNetworkName(args)
+
         def hash=[
 
                 "Hostname": serviceName,
@@ -729,6 +741,14 @@ public class DockerClient extends BaseClient {
                     ]
             ]
         
+        if(networkName!=null){
+            hash["NetworkingConfig"] = [
+                "EndpointsConfig": [
+                    (networkName): [:]
+                ]
+            ]            
+        }
+
         return [hash,encodedAuthConfig]
        
     }

--- a/pages/help.xml
+++ b/pages/help.xml
@@ -193,7 +193,7 @@
             </div>  
             <div id="DeployService">
                 <h2>Deploy Service</h2>
-                <p>This procedure deploys container on stand-alone Docker engine or Docker Swarm service on already setup Docker Swarm cluster</p>
+                <p>This procedure deploys container on stand-alone Docker engine or Docker Swarm service on already setup Docker Swarm cluster. In case of Docker Swarm service, plugin also creates overlay network with name "&lt;flow_application_name&gt;-default" if it does not exists already. Name / type of the network can be overridden in service mapping override page. Type of Docker networks supported are "Overlay" and "Ingress". </p>
                 <h3>Deploy Service Parameters</h3>
                 <table class="grid">
                     <thead>

--- a/pages/help.xml
+++ b/pages/help.xml
@@ -193,7 +193,7 @@
             </div>  
             <div id="DeployService">
                 <h2>Deploy Service</h2>
-                <p>This procedure deploys container on stand-alone Docker engine or Docker Swarm service on already setup Docker Swarm cluster. In case of Docker Swarm service, plugin also creates overlay network with name "&lt;flow_application_name&gt;-default" if it does not exists already. Name / type of the network can be overridden in service mapping override page. Type of Docker networks supported are "Overlay" and "Ingress". </p>
+                <p>This procedure deploys container on stand-alone Docker engine or Docker Swarm service on already setup Docker Swarm cluster. In case of Docker Swarm service, plugin also creates overlay network if specified in service mapping override page. Type of Docker networks supported are "Overlay" and "Ingress". If no network name is specified, plugin deploys service in default Ingress network.</p>
                 <h3>Deploy Service Parameters</h3>
                 <table class="grid">
                     <thead>

--- a/pages/help.xml
+++ b/pages/help.xml
@@ -699,6 +699,14 @@
                 and so on.
                 - Descriptions of new features or functionality supported by the plugin.
                 -->
+        <h2>EC-Docker-1.2.1</h2>
+        <ul>
+            <li>Added support for Docker network creation</li>
+                <ul>
+                    <li>For Stand-alone Docker instances, <i>Deploy Service</i> procedure creates a user defined bridge network if network name given in service mapping page. Procedure uses this network to deploy containers.</li>
+                    <li>For Docker Swarm instances, <i>Deploy Service</i> procedure creates a user defined overlay network if network name given in service mapping page. Procedure uses this network to deploy Docker Swarm services.</li>
+                </ul>
+        </ul>
         <h2>EC-Docker-1.2.0</h2>
         <ul>
             <li>Added support for deploying micro-services modeled in ElectricFlow to Docker. Deploying micro-services to the following Docker environments are supported:

--- a/pages/help.xml
+++ b/pages/help.xml
@@ -193,7 +193,7 @@
             </div>  
             <div id="DeployService">
                 <h2>Deploy Service</h2>
-                <p>This procedure deploys container on stand-alone Docker engine or Docker Swarm service on already setup Docker Swarm cluster. In case of Docker Swarm service, plugin also creates overlay network if specified in service mapping override page. Type of Docker networks supported are "Overlay" and "Ingress". If no network name is specified, plugin deploys service in default Ingress network.</p>
+                <p>This procedure deploys container on stand-alone Docker engine or Docker Swarm service on already setup Docker Swarm cluster. In case of Docker Swarm service, plugin also creates overlay network if specified in service mapping override page. Type of Docker networks supported are "Overlay" and "Ingress". If no network name is specified, plugin deploys service in default Ingress network. In case of standalone Docker engine, plugin deploys container in default bridge (docker0) network. Default bridge network does not support service discovery. If this feature is needed then user must provide custom network name and network type as "Bridge" in service mapping override page. With these details, plugin creates user defined bridge network and deploys container within this network. For more info on docker networking, see <a href="https://docs.docker.com/engine/userguide/networking/">here</a></p>
                 <h3>Deploy Service Parameters</h3>
                 <table class="grid">
                     <thead>


### PR DESCRIPTION
Modified plugin to

1. In case of  Docker Swarm, create overlay network if specified in service mapping override page. Type of Docker networks supported are `Overlay` and `Ingress`. If no network name is specified, plugin deploys service in default Ingress network. 

2. In case of standalone Docker engine, plugin deploys container in default bridge (`docker0`) network. Default bridge network does not support service discovery. If this feature is needed then user must provide custom network name and network type as `Bridge` in service mapping override page. With these details, plugin creates user defined bridge network and deploys container within this network.