### PR TITLE
Added serviceEntityRevisionId to deploy/undeploy service procedures

### DIFF
--- a/dsl/procedures/deployService/form.xml
+++ b/dsl/procedures/deployService/form.xml
@@ -25,6 +25,13 @@
     </formElement>
     <formElement>
         <type>entry</type>
+        <label>Service Revision ID:</label>
+        <property>serviceEntityRevisionId</property>
+        <required>0</required>
+        <documentation>Revision Id of the service in ElectricFlow.</documentation>
+    </formElement>
+    <formElement>
+        <type>entry</type>
         <label>Project Name:</label>
         <property>serviceProjectName</property>
         <required>1</required>

--- a/dsl/procedures/deployService/steps/createOrUpdateDeployment.groovy
+++ b/dsl/procedures/deployService/steps/createOrUpdateDeployment.groovy
@@ -12,6 +12,7 @@ if (!clusterOrEnvProjectName) {
 }
 String environmentName = '$[environmentName]'
 String applicationRevisionId = '$[applicationRevisionId]'
+String serviceEntityRevisionId = '$[serviceEntityRevisionId]'
 
 String resultsPropertySheet = '$[resultsPropertySheet]'
 if (!resultsPropertySheet) {
@@ -28,7 +29,7 @@ DockerClient dockerClient = new DockerClient(pluginConfig)
 //def pluginConfig = dockerClient.getPluginConfig(efClient, clusterName, clusterOrEnvProjectName, environmentName)
 def clusterEndpoint = pluginConfig.endpoint
 
-println "serviceName: ${serviceName} serviceProjectName:${serviceProjectName} applicationName:${applicationName} clusterName:${clusterName} clusterOrEnvProjectName:${clusterOrEnvProjectName} environmentName:${environmentName} clusterEndpoint:${clusterEndpoint} applicationRevisionId:${applicationRevisionId}"
+println "serviceName: ${serviceName} serviceEntityRevisionId: ${serviceEntityRevisionId} serviceProjectName:${serviceProjectName} applicationName:${applicationName} clusterName:${clusterName} clusterOrEnvProjectName:${clusterOrEnvProjectName} environmentName:${environmentName} clusterEndpoint:${clusterEndpoint} applicationRevisionId:${applicationRevisionId}"
 
 dockerClient.deployService(
 		        efClient,    
@@ -40,4 +41,5 @@ dockerClient.deployService(
 		        clusterName,
 		        clusterOrEnvProjectName,
 		        environmentName,
-		        resultsPropertySheet)
+		        resultsPropertySheet,
+				serviceEntityRevisionId)

--- a/dsl/procedures/undeployService/form.xml
+++ b/dsl/procedures/undeployService/form.xml
@@ -25,6 +25,13 @@
     </formElement>
     <formElement>
         <type>entry</type>
+        <label>Service Revision ID:</label>
+        <property>serviceEntityRevisionId</property>
+        <required>0</required>
+        <documentation>Revision Id of the service in ElectricFlow.</documentation>
+    </formElement>
+    <formElement>
+        <type>entry</type>
         <label>Project Name:</label>
         <property>serviceProjectName</property>
         <required>1</required>

--- a/dsl/procedures/undeployService/steps/undeployService.groovy
+++ b/dsl/procedures/undeployService/steps/undeployService.groovy
@@ -12,6 +12,7 @@ if (!envProjectName) {
 }
 String environmentName = '$[environmentName]'
 String applicationRevisionId = '$[applicationRevisionId]'
+String serviceEntityRevisionId = '$[serviceEntityRevisionId]'
 
 def pluginProjectName = '$[/myProject/projectName]'
 
@@ -19,6 +20,9 @@ def pluginProjectName = '$[/myProject/projectName]'
 EFClient efClient = new EFClient()
 // if cluster is not specified, find the cluster based on the environment that the application is mapped to.
 if (!clusterName) {
+	if (!applicationName) {
+		efClient.handleError("'applicationName' must be specified if 'clusterName' is not specified in order to determine the cluster")
+	}
 	clusterName = efClient.getServiceCluster(serviceName,
 			serviceProjectName,
 			applicationName,
@@ -44,5 +48,6 @@ dockerClient.undeployService(
 		applicationRevisionId,
 		clusterName,
 		envProjectName,
-		environmentName)
+		environmentName,
+		serviceEntityRevisionId)
 

--- a/dsl/promote.groovy
+++ b/dsl/promote.groovy
@@ -100,6 +100,7 @@ project pluginName, {
 					property 'clusterName', value: 'clusterName'
 					property 'clusterOrEnvironmentProjectName', value: 'clusterOrEnvProjectName'
 					property 'environmentName', value: 'environmentName'
+					property 'serviceEntityRevisionId', value: 'serviceEntityRevisionId'
 				}
 			}
 			property 'deleteConfiguration', {

--- a/dsl/properties/scripts/DockerClient.groovy
+++ b/dsl/properties/scripts/DockerClient.groovy
@@ -131,7 +131,8 @@ public class DockerClient extends BaseClient {
             String clusterName,
             String clusterOrEnvProjectName,
             String environmentName,
-            String resultsPropertySheet){
+            String resultsPropertySheet,
+            String serviceEntityRevisionId){
 
        
         def serviceDetails = efClient.getServiceDeploymentDetails(
@@ -141,7 +142,8 @@ public class DockerClient extends BaseClient {
                 applicationRevisionId,
                 clusterName,
                 clusterOrEnvProjectName,
-                environmentName)
+                environmentName,
+                serviceEntityRevisionId)
 
         if(serviceDetails.container.size() > 1){
             efClient.handleProcedureError("Services in Docker do not support multiple container images within one service. ${serviceDetails.container.size()} container definitions were found in the ElectricFlow service definition for '${serviceName}'.")
@@ -172,7 +174,8 @@ public class DockerClient extends BaseClient {
             String applicationRevisionId,
             String clusterName,
             String envProjectName,
-            String environmentName){
+            String environmentName,
+            String serviceEntityRevisionId){
 
 
         logger INFO, "Undeploying ElectricFlow service: ${serviceName} in service project:${serviceProjectName} application:${applicationName} cluster:${clusterName} environment project:${envProjectName} environment name:${environmentName} cluster endpoint:${clusterEndpoint}"
@@ -184,7 +187,8 @@ public class DockerClient extends BaseClient {
                 applicationRevisionId,
                 clusterName,
                 envProjectName,
-                environmentName)
+                environmentName,
+                serviceEntityRevisionId)
 
         if (OFFLINE) return null
 

--- a/dsl/properties/scripts/EFClient.groovy
+++ b/dsl/properties/scripts/EFClient.groovy
@@ -132,7 +132,8 @@ public class EFClient extends BaseClient {
                                     String applicationRevisionId,
                                     String clusterName,
                                     String clusterProjectName,
-                                    String environmentName) {
+                                    String environmentName,
+                                    String serviceEntityRevisionId) {
 
         def partialUri = applicationName ?
                 "projects/$serviceProjectName/applications/$applicationName/services/$serviceName" :
@@ -145,6 +146,9 @@ public class EFClient extends BaseClient {
                 applicationEntityRevisionId: applicationRevisionId,
                 jobStepId: System.getenv('COMMANDER_JOBSTEPID')
         ]
+        if (serviceEntityRevisionId) {
+            queryArgs << [serviceEntityRevisionId: serviceEntityRevisionId]
+        }
         def result = doHttpGet("/rest/v1.0/$partialUri", /*failOnErrorCode*/ true, queryArgs)
 
         def svcDetails = result.data.service

--- a/pages/help.xml
+++ b/pages/help.xml
@@ -236,7 +236,11 @@
                             <td>The name of the service in ElectricFlow that encapsulates the service to be deployed on a stand-alone Docker host or a Docker Swarm cluster.</td>
                         </tr>
                         <tr>
-                            <td class="required">Service Project Name</td>
+                            <td>Service Revision ID</td>
+                            <td>Revision Id of the service in ElectricFlow.</td>
+                        </tr>
+                        <tr>
+                            <td class="required">Project Name</td>
                             <td>The name of the project that the service belongs to. In case of an application-level service it also owns the application.</td>
                         </tr>
                         <tr>
@@ -305,7 +309,10 @@
                             <td class="required">Service Name*</td>
                             <td>The name of the service in ElectricFlow that encapsulates the service that was previously deployed on a stand-alone Docker host or a Docker Swarm cluster.</td>
                         </tr>
-
+                        <tr>
+                            <td>Service Revision ID</td>
+                            <td>Revision Id of the service in ElectricFlow.</td>
+                        </tr>
                         <tr>
                             <td class="required">Project Name</td>
                             <td>The name of the project that the service belongs to. In case of an application-level service it also owns the application.</td>


### PR DESCRIPTION
serviceEntityRevisionId is passed to getServiceDeploymentDetails if specified to lookup the service revision as required. On EF < 8.1, clients should not specify a value for serviceEntityRevisionId so that the plugin will skip sending it in the getServiceDeploymentDetails call.