### PR TITLE
Escaped pipe characters in the adoc field to fix rendering issue.

### DIFF
--- a/config/pluginspec.yaml
+++ b/config/pluginspec.yaml
@@ -45,7 +45,7 @@ properties:
     path: "dsl/properties/postpLoader"
 procedures:
 - name: "runDockerBuild"
-  description: "This procedure performs a Docker build."
+  description: "Performs a Docker build."
   hasConfig: true
   parameters:
   - name: "use_sudo"
@@ -66,7 +66,7 @@ procedures:
   shell: "ec-perl"
   properties: []
 - name: "runDockerPull"
-  description: "This procedure performs a Docker pull on the requested image."
+  description: "Performs a Docker pull on the requested image."
   hasConfig: true
   parameters:
   - name: "use_sudo"
@@ -93,7 +93,7 @@ procedures:
   shell: "ec-perl"
   properties: []
 - name: "runDockerRun"
-  description: "This procedure performs a Docker run."
+  description: "Performs a Docker run."
   hasConfig: true
   parameters:
   - name: "use_sudo"

--- a/config/pluginspec.yaml
+++ b/config/pluginspec.yaml
@@ -45,7 +45,7 @@ properties:
     path: "dsl/properties/postpLoader"
 procedures:
 - name: "runDockerBuild"
-  description: "Performs a Docker build."
+  description: "This procedure performs a Docker build."
   hasConfig: true
   parameters:
   - name: "use_sudo"
@@ -66,7 +66,7 @@ procedures:
   shell: "ec-perl"
   properties: []
 - name: "runDockerPull"
-  description: "Performs a Docker pull on the requested image."
+  description: "This procedure performs a Docker pull on the requested image."
   hasConfig: true
   parameters:
   - name: "use_sudo"
@@ -93,7 +93,7 @@ procedures:
   shell: "ec-perl"
   properties: []
 - name: "runDockerRun"
-  description: "Performs a Docker run."
+  description: "This procedure performs a Docker run."
   hasConfig: true
   parameters:
   - name: "use_sudo"

--- a/config/pluginspec.yaml
+++ b/config/pluginspec.yaml
@@ -143,7 +143,7 @@ procedures:
     type: "entry"
     required: false
     adoc: |
-      Publish a container's port to the host using the following format: `ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort`.
+      Publish a container's port to the host using the following format: `ip:hostPort:containerPort \| ip::containerPort \| hostPort:containerPort \| containerPort`.
       
       NOTE: Use spaces to delimit port mappings. For example, `2666:1666 8088:8080`.
     documentation: "Publish a container's port to the host using the following format: ip:hostPort:containerPort\


### PR DESCRIPTION
The pipe characters were not properly escaped in the `adoc` field, causing rendering issues for the procedure table in the documentation. This has been fixed.

Note that I did not update this for the `documentation` field because I believe this is the content used for text strings in the React UI if the `htmlDocumentation` field is not present in the pluginspec.yaml.