### PR TITLE
Error message text changes for `RunDockerBuild Negative with wrong build path` procedure spec.

### DIFF
--- a/specs/src/test/groovy/com/cloudbees/pdk/hen/tests/RunDockerBuildSuite.groovy
+++ b/specs/src/test/groovy/com/cloudbees/pdk/hen/tests/RunDockerBuildSuite.groovy
@@ -76,7 +76,7 @@ class RunDockerBuildSuite extends Specification {
         then:
         def jobLog = result.getJobLog()
         assert result.getOutcome().toString() == 'ERROR'
-        assert jobLog.contains('ERROR: unable to prepare context: path "/tmp/wrong-specs-dockerfile/" not found')
+        assert jobLog.contains('unable to prepare context: path "/tmp/wrong-specs-dockerfile/" not found')
         assert jobLog.contains('Exit code: 256')
 
         cleanup:


### PR DESCRIPTION
JIRA - https://cloudbees.atlassian.net/browse/CDRO-8861
**Description:**
The build failed because the **RunDockerBuildSuite** procedure's error message changed. 
Previous error message - `ERROR: unable to prepare context: path "/tmp/wrong-specs-dockerfile/" not found`
Current error message - `ERROR: failed to build: unable to prepare context: path "/tmp/wrong-specs-dockerfile/" not found`