### PR TITLE
Chandra-adding plugin version check for spec test

### DIFF
--- a/specs/build.gradle
+++ b/specs/build.gradle
@@ -56,7 +56,7 @@ ext {
 
     spockVersion = "2.4-M1-groovy-3.0"
 
-    specCoreVersion = "3.0.0"
+    specCoreVersion = "3.0.1"
 
     restAssuredVersion = "5.3.1"
 

--- a/specs/src/test/groovy/com/cloudbees/plugin/spec/PluginHelper.groovy
+++ b/specs/src/test/groovy/com/cloudbees/plugin/spec/PluginHelper.groovy
@@ -21,47 +21,4 @@ class PluginHelper extends PluginSpockTestSupport{
         }
         return value
     }
-
-    def getPlugin(def pluginName) {
-        def result = dsl """
-                        getPlugin(pluginName: '$pluginName')
-                    """
-        return result
-    }
-
-    /**
-     * Parses the plugin info map and returns ONLY the version string.
-     *
-     * @return The version string (e.g., "2.0.1.2025011751") if found,
-     * @throws RuntimeException if the pluginVersion field is missing, empty,
-     * or does not contain a valid version.
-     */
-    def getPluginVersion() {
-        Map pluginInfo = getPlugin(PLUGIN_NAME)
-        print("Plugin Info: $pluginInfo\n")
-
-        def versionStr = pluginInfo?.plugin?.pluginVersion?.toString()
-
-        if (versionStr == null || versionStr.trim().empty) {
-            throw new RuntimeException("Invalid Response: 'plugin.pluginVersion' field is missing or empty.")
-        }
-
-        return versionStr.trim()
-    }
-    /**
-     * Helper method to compare semantic versions
-     * @param current Current version string (e.g., "2.0.1.2025011751")
-     * @param minimum Minimum required version (e.g., "2.0.0")
-     * @return true if current >= minimum
-     */
-    protected boolean isVersionAtLeast(String current, String minimum) {
-        def currentParts = current.tokenize('.').collect { it.toInteger() }
-        def minimumParts = minimum.tokenize('.').collect { it.toInteger() }
-
-        for (int i = 0; i < Math.min(currentParts.size(), minimumParts.size()); i++) {
-            if (currentParts[i] > minimumParts[i]) return true
-            if (currentParts[i] < minimumParts[i]) return false
-        }
-        return currentParts.size() >= minimumParts.size()
-    }
 }

--- a/specs/src/test/groovy/com/cloudbees/plugin/spec/TestConfigurationSpec.groovy
+++ b/specs/src/test/groovy/com/cloudbees/plugin/spec/TestConfigurationSpec.groovy
@@ -2,7 +2,6 @@ package com.cloudbees.plugin.spec
 
 import com.cloudbees.pdk.hen.Docker
 import com.cloudbees.pdk.hen.ServerHandler
-import com.electriccloud.plugins.annotations.NewFeature
 import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -18,7 +17,7 @@ class TestConfigurationSpec extends PluginHelper {
     def setupSpec() {
         plugin = Docker.createWithoutConfig()
         ServerHandler.getInstance().setupResource("docker-resource", "docker", 7808)
-        version = pluginVersion
+        version = getPluginVersion(PLUGIN_NAME)
     }
 
     def cleanupSpec() {


### PR DESCRIPTION
Changed the plugin version check as [ec-specs-plugins-core 3.0.1](https://artifacts.cloudbees.com/#browse/search/generic=keyword%3Dec-specs-plugins-core:maven2-66921d6e) version got released.
This should prevent us from plugin build failures due to plugin version mismatch for EC-Docker